### PR TITLE
removing CORS issues from Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true #ENV['RAILS_SERVE_STATIC_FILES'].present?
 
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
Trying to fix new CORS issues once Knock was added to the file.  I am using the rails cors gem so not sure why Heroku is having issues.  I have updated the config.public_file_server.enabled = true in the application.rb config file ot hoopefully fix the issue.  