### PR TITLE
post requests for users and phrases

### DIFF
--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -1,5 +1,5 @@
 class PhrasesController < ApplicationController
-  before_action :authenticate_user
+  before_action :authenticate_user, only: [:index]
   before_action :set_phrase, only: [:show, :update, :destroy]
 
   # GET /phrases
@@ -20,6 +20,7 @@ class PhrasesController < ApplicationController
     @phrase = Phrase.new(phrase_params)
 
     if @phrase.save
+      current_user.phrases << @phrase
       render json: @phrase, status: :created, location: @phrase
     else
       render json: @phrase.errors, status: :unprocessable_entity
@@ -48,6 +49,6 @@ class PhrasesController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def phrase_params
-      params.require(:phrase).permit(:phrase, :language)
+      params.permit(:phrase, :language, :user_id)
     end
 end

--- a/app/controllers/phrases_controller.rb
+++ b/app/controllers/phrases_controller.rb
@@ -1,10 +1,11 @@
 class PhrasesController < ApplicationController
-  #before_action :authenticate_user
+  before_action :authenticate_user
   before_action :set_phrase, only: [:show, :update, :destroy]
 
   # GET /phrases
   def index
-    @phrases = Phrase.all
+    @phrases = current_user.phrases
+    #@phrases = Phrase.all
 
     render json: @phrases
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,17 @@ Rails.application.routes.draw do
   get "/password", to: "password#show"
 
   scope "/api" do
-    #list all phrases for everyone, with password verification so only logged in users can see
-    #the front end will parese the data and only show the user their phrases
+    #only shows current users phrases
     get "/phrases", to: "phrases#index"
+
+    #create new phrase
+    post "/phrases", to: "phrases#create"
 
     #if credientals are valid, knock returns an access token for the api
     post "user_token" => "user_token#create"
+
+    #add new user
+    post "/users", to: "users#create"
 
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20171029152259) do
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
-    t.boolean "admin"
+    t.boolean "admin", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@ EMAIL.map do |email|
   puts("user #{email} created!")
 end
 
-User.create(email: 'bret', password: "test")
+User.create(email: 'bret@bret', password: "test")
 User.last.phrases << Phrase.first
 User.last.phrases << Phrase.last
 puts("user #{User.last.email} created!")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,11 +3,13 @@ PHRASES = ['Help', 'Elenor Rigby', 'I want to hold your hand', 'All you need is 
 EMAIL.map do |email|
   new_user = User.create(email: email, password: "Test")
   3.times { new_user.phrases << Phrase.create(phrase: PHRASES.sample, language: "English") }
+  puts("user #{email} created!")
+end
 
-User.create(email: 'bret@bret', password: "test")
+User.create(email: 'bret', password: "test")
 User.last.phrases << Phrase.first
 User.last.phrases << Phrase.last
-end
+puts("user #{User.last.email} created!")
 
 
 


### PR DESCRIPTION
The backend now allows users and phrases to be created from the front end using APIs.  The APIs are unprotected so you can create a user without logging in first, ha, but further down the road maybe protecting the APIs somehow would make sense.  This data is not sensitive and they cannot get request the phrases or users so possibly not a bit deal. 
 
Next steps
-testing
-possible refacting
-making any additional changes
-documentation